### PR TITLE
Bug fix for 3D labeling tool GUI

### DIFF
--- a/front/app/labeling_tool/annotation.js
+++ b/front/app/labeling_tool/annotation.js
@@ -42,6 +42,7 @@ export default class Annotation {
               const id = tool.candidateId;
               if (obj.content[id] != null) {
                 bboxes[id] = tool.createBBox(obj.content[id]);
+                tool._redrawFlag = true;
               }
             });
             let label = new Label(this, obj.object_id, klass, bboxes);

--- a/front/app/labeling_tool/pcd_label_tool.js
+++ b/front/app/labeling_tool/pcd_label_tool.js
@@ -15,6 +15,7 @@ export default class PCDLabelTool{
   _scene = null;
   _renderer = null;
   _camera = null;
+  _camera_scale = 50;
   _controls = null;
   //cameraExMat = new THREE.Matrix4();
   // PCD objects
@@ -81,6 +82,7 @@ export default class PCDLabelTool{
     // use preloaded pcd mesh
     if (this._pointMeshes[frame] != null) {
       this._pointMeshes[frame].visible =true;
+      this._redrawFlag = true;
       this._loaded = true;
       return Promise.resolve();
     }
@@ -106,6 +108,25 @@ export default class PCDLabelTool{
       camera.updateProjectionMatrix();
       renderer.setSize( window.innerWidth, window.innerHeight );
       */
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      // fix camera aspect
+      if (this._camera.inPerspectiveMode) {
+        this._camera.aspect = width / height;
+      } else {
+        this._camera.left = -width / this._camera_scale;
+        this._camera.right = width / this._camera_scale;
+        this._camera.top = height / this._camera_scale;
+        this._camera.bottom = -height / this._camera_scale;
+      }
+      this._camera.updateProjectionMatrix();
+
+      // re-set render size
+      this._renderer.setPixelRatio(window.devicePixelRatio);
+      this._renderer.setSize(width, height);
+
+      this._redrawFlag = true;
     },
     keydown: (e) => {
       if (e.keyCode === 16) { // shift
@@ -203,11 +224,23 @@ export default class PCDLabelTool{
     // TODO: read YAML and set camera?
     let camera;
     if(this._isBirdView){
-      camera = new THREE.OrthographicCamera (-40,40,20,-20, 10, 2000);
-      camera.position.set (0,0,450);
-      camera.lookAt (new THREE.Vector3(0,0,0));
-    }else{
-      camera = new THREE.PerspectiveCamera( 90, window.innerWidth / window.innerHeight, 0.01, 10000 );
+      camera = new THREE.OrthographicCamera(
+        -window.innerWidth / this._camera_scale,
+        window.innerWidth / this._camera_scale,
+        window.innerHeight / this._camera_scale,
+        -window.innerHeight / this._camera_scale,
+        10,
+        2000
+      );
+      camera.position.set(0, 0, 450);
+      camera.lookAt(new THREE.Vector3(0, 0, 0));
+    } else {
+      camera = new THREE.PerspectiveCamera(
+        90,
+        window.innerWidth / window.innerHeight,
+        0.01,
+        10000
+      );
       camera.position.set(0,0,0.5);
     }
     camera.up.set (0,0,1);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
This PR is one of the action items described in #10.
- Fixed the bug that the aspect ratio of the point-cloud/boxes in the labeling tool was changed by resizing the browser
- Fixed the problem that points are not re-rendered when moving to the previous frame
- Fixed the bug that PCD boxes were not displayed when moving frames

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
![pr1](https://user-images.githubusercontent.com/24401842/63411772-38fc2100-c431-11e9-8036-a3ab73659af3.gif)

