### PR TITLE
Fix error at initial installation caused by Debian package name of mysql client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt update && \
     libsqlite3-dev \
     libssl-dev \
     llvm \
-    mysql-client \
+    default-mysql-client \
     tk-dev \
     wget \
     xz-utils \


### PR DESCRIPTION
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description

I've faced the following error at initial installation (building docker image):
```sh
vagrant@automan-labeling:~/kube/AutomanTools$ sudo docker build -t automan-labeling-app .
```
```
...
Reading package lists...
Building dependency tree...
Reading state information...
Package mysql-client is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'mysql-client' has no installation candidate
The command '/bin/bash -c apt update &&     apt install -y --no-install-recommends     apt-transport-https     default-libmysqlclient-dev     ca-certificates     curl     build-essential     iputils-ping     gnupg2     libbz2-dev     libffi-dev     liblzma-dev     libncurses5-dev     libncursesw5-dev     libreadline-dev     libsqlite3-dev     libssl-dev     llvm     mysql-client     tk-dev     wget     xz-utils     zlib1g-dev &&     apt clean &&     rm -rf /var/lib/apt/lists/* &&     pip install --no-cache-dir pipenv &&     curl -sL https://deb.nodesource.com/setup_10.x | bash - &&     apt install -y nodejs &&     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&     apt update && apt install -y yarn' returned a non-zero code: 100
```

The `mysql-client` package has transitioned to `default-mysql-client`, so I've changed the package name in Dockerfile.

## Related Tickets & Documents

- [Debianのdockerイメージでmysql-clientが無くてハマった人へ](https://qiita.com/henrich/items/1b7ee2f3a72f8bb29cba)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
