### PR TITLE
Reload table automatically

### DIFF
--- a/front/app/dashboard/components/calibration/entry.jsx
+++ b/front/app/dashboard/components/calibration/entry.jsx
@@ -16,21 +16,33 @@ import { mainStyle } from 'automan/assets/main-style';
 class CalibrationPage extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { formOpen: false };
+    this.state = {
+      formOpen: false,
+      needUpdate: false
+    };
   }
   show = () => {
     this.setState({ formOpen: true });
   };
-  hide = () => {
-    this.setState({ formOpen: false });
+  hide = (isUploaded) => {
+    this.setState({
+      formOpen: false,
+      needUpdate: isUploaded
+    });
   };
+  handleUpdate = () => {
+    this.setState({ needUpdate: false });
+  }
   render() {
     const { classes } = this.props;
     return (
       <Grid container spacing={24}>
         <Grid item xs={12}>
           <Paper className={classes.root}>
-            <CalibrationTable />
+            <CalibrationTable
+              handleUpdate={this.handleUpdate}
+              needUpdate={this.state.needUpdate}
+            />
           </Paper>
           <Tooltip title="Upload">
             <Fab

--- a/front/app/dashboard/components/calibration/form.jsx
+++ b/front/app/dashboard/components/calibration/form.jsx
@@ -85,12 +85,12 @@ class CalibrationForm extends React.Component {
     this.nextFileUpload(0);
   };
   hide = () => {
+    this.props.hide(this.state.isUploaded);
     this.setState({
       uploadFiles: [],
       targetFileIndex: null,
       isUploaded: false
     });
-    this.props.hide();
   };
   render() {
     const { uploadFiles, isUploaded } = this.state;

--- a/front/app/dashboard/components/calibration/table.jsx
+++ b/front/app/dashboard/components/calibration/table.jsx
@@ -43,8 +43,10 @@ class CalibrationTable extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     if (
       prevProps.currentProject == null ||
-      this.props.currentProject.id !== prevProps.currentProject.id
+      this.props.currentProject.id !== prevProps.currentProject.id ||
+      this.props.needUpdate
     ) {
+      this.props.handleUpdate();
       this.updateData();
     }
   }

--- a/front/app/dashboard/components/calibration/table.jsx
+++ b/front/app/dashboard/components/calibration/table.jsx
@@ -18,7 +18,7 @@ function nameFormatter(cell, row) {
 }
 function valueFormatter(cell, row) {
   return (
-    <div style={{whiteSpace: 'pre-line'}}>
+    <div style={{ whiteSpace: 'pre-line' }}>
       {row.value}
     </div>
   );

--- a/front/app/dashboard/components/job/table.jsx
+++ b/front/app/dashboard/components/job/table.jsx
@@ -13,6 +13,8 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import RefreshIcon from '@material-ui/icons/Refresh';
 
 import { mainStyle } from 'automan/assets/main-style';
 import ResizableTable from 'automan/dashboard/components/parts/resizable_table';
@@ -249,6 +251,17 @@ class JobTable extends React.Component {
       searchDelayTime: 1000
     };
     options.onRowClick = (row, colIndex, rowIndex) => {};
+    const refreshButton = (
+      <Tooltip title="Refresh">
+        <IconButton
+          color="primary"
+          className={classes.Refresh}
+          onClick={(e) => this.updateData(e)}
+        >
+          <RefreshIcon />
+        </IconButton>
+      </Tooltip>
+    );
     const fetchProp = {
       dataTotalSize: this.state.total_count
     };
@@ -257,6 +270,7 @@ class JobTable extends React.Component {
       <div className={classes.tableWrapper}>
         <Typography variant="h6" id="tableTitle">
           Jobs
+          {refreshButton}
         </Typography>
         <ResizableTable
           data={rows}

--- a/front/app/dashboard/components/mypage/entry.jsx
+++ b/front/app/dashboard/components/mypage/entry.jsx
@@ -18,7 +18,8 @@ class MyPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      open: false
+      open: false,
+      needUpdate: false
     };
     this.updateData();
   }
@@ -29,9 +30,13 @@ class MyPage extends React.Component {
     this.setState({ open: false });
   };
   handlePostSubmit = () => {
+    this.setState({ needUpdate: true });
     this.updateData();
     this.hide();
   };
+  handleUpdate = () => {
+    this.setState({ needUpdate: false });
+  }
   updateData() {
     this.props.dispatchCurrentUser();
   }
@@ -51,7 +56,10 @@ class MyPage extends React.Component {
         </Grid>
         <Grid item xs={12}>
           <Paper className={classes.root}>
-            <ProjectTable />
+            <ProjectTable
+              handleUpdate={this.handleUpdate}
+              needUpdate={this.state.needUpdate}
+            />
           </Paper>
           <Fab
             color="primary"

--- a/front/app/dashboard/components/mypage/project_form.jsx
+++ b/front/app/dashboard/components/mypage/project_form.jsx
@@ -157,7 +157,14 @@ export default class Popup extends React.Component {
       '/projects/',
       data,
       res => {
-        this.setState({ result: 'Success' });
+        this.setState({
+          result: 'Success',
+          name: '',
+          description: '',
+          labelType: null,
+          activeStep: 0,
+          klasses: []
+        });
         this.props.handlePostSubmit();
       },
       res => {

--- a/front/app/dashboard/components/mypage/project_table.jsx
+++ b/front/app/dashboard/components/mypage/project_table.jsx
@@ -141,7 +141,7 @@ class ProjectTable extends React.Component {
           fetchInfo={fetchProp}
         >
           <TableHeaderColumn width="20%" dataField="name" isKey dataSort={true}>
-            Name
+            Project Name
           </TableHeaderColumn>
           <TableHeaderColumn width="" dataField="description" dataSort={true}>
             Description

--- a/front/app/dashboard/components/mypage/project_table.jsx
+++ b/front/app/dashboard/components/mypage/project_table.jsx
@@ -24,6 +24,12 @@ class ProjectTable extends React.Component {
   componentDidMount = () => {
     this.updateData();
   };
+  componentDidUpdate = () => {
+    if (this.props.needUpdate) {
+      this.props.handleUpdate();
+      this.updateData();
+    }
+  }
   updateData = () => {
     this.setState({ data: [], is_loading: true, error: null });
 

--- a/front/app/dashboard/components/original/entry.jsx
+++ b/front/app/dashboard/components/original/entry.jsx
@@ -39,7 +39,6 @@ class OriginalPage extends React.Component {
     });
   };
   hideAndUpdate = (isUploaded) => {
-    console.log(isUploaded);
     this.setState({ needUpdate: isUploaded });
     this.hide();
   };

--- a/front/app/dashboard/components/original/entry.jsx
+++ b/front/app/dashboard/components/original/entry.jsx
@@ -23,7 +23,8 @@ class OriginalPage extends React.Component {
       extractorSnackbar: false,
       analyzerSnackbar: false,
       original_id: 0,
-      message: null
+      message: null,
+      needUpdate: false
     };
   }
   show = () => {
@@ -37,6 +38,14 @@ class OriginalPage extends React.Component {
       extractorSnackbar: false
     });
   };
+  hideAndUpdate = (isUploaded) => {
+    console.log(isUploaded);
+    this.setState({ needUpdate: isUploaded });
+    this.hide();
+  };
+  handleUpdate = () => {
+    this.setState({ needUpdate: false });
+  }
   analyzerSubmit = (original_id) => {
     const data = {
       job_type: 'ANALYZER',
@@ -76,6 +85,8 @@ class OriginalPage extends React.Component {
               extractorFormShow={this.extractorFormShow}
               analyzerSubmit={this.analyzerSubmit}
               hide={this.hide}
+              handleUpdate={this.handleUpdate}
+              needUpdate={this.state.needUpdate}
             />
           </Paper>
           <Tooltip title="Upload">
@@ -90,7 +101,7 @@ class OriginalPage extends React.Component {
               <CloudUpload />
             </Fab>
           </Tooltip>
-          <OriginalDataForm formOpen={this.state.formOpen} hide={this.hide} />
+          <OriginalDataForm formOpen={this.state.formOpen} hide={this.hideAndUpdate} />
           <ExtractorForm
             formOpen={this.state.extractorFormOpen}
             hide={this.hide}

--- a/front/app/dashboard/components/original/form.jsx
+++ b/front/app/dashboard/components/original/form.jsx
@@ -176,12 +176,12 @@ class OriginalDataForm extends React.Component {
     this.nextFileUpload(0);
   };
   hide = () => {
+    this.props.hide(this.state.isUploaded)
     this.setState({
       uploadFiles: [],
       targetFileIndex: null,
       isUploaded: false
     });
-    this.props.hide()
   };
   render() {
     const { classes } = this.props;

--- a/front/app/dashboard/components/original/table.jsx
+++ b/front/app/dashboard/components/original/table.jsx
@@ -36,8 +36,10 @@ class OriginalTable extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     if (
       prevProps.currentProject == null ||
-      this.props.currentProject.id !== prevProps.currentProject.id
+      this.props.currentProject.id !== prevProps.currentProject.id ||
+      this.props.needUpdate
     ) {
+      this.props.handleUpdate();
       this.updateData();
     }
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Other

## Description
- The table on each page is not refreshed automatically when rows are added.
- The `job` table needs to be manually refreshed to see the results

## Related Tickets & Documents
This PR is related to https://github.com/tier4/AutomanTools/issues/28

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
- `Refresh button` added on the `Jobs` page
![image](https://user-images.githubusercontent.com/39268318/67914325-2a6d7b00-fbd3-11e9-8602-48a8f0d1e8f6.png)
