### PR TITLE
Fix set_height in labeling tool

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -193,7 +193,13 @@ export default class PCDLabelTool extends React.Component {
   }
   // button actions
   setHeight = () => {
-    const bboxes = Array.from(this.pcdBBoxes);
+    let bboxes;
+    const tgt = this._controls.getTargetLabel();
+    if (tgt !== null) {
+      bboxes = [tgt.bbox[this.candidateId]];
+    } else {
+      bboxes = Array.from(this.pcdBBoxes);
+    }
     const posArray = this._currentPointMesh.geometry.getAttribute('position').array;
     let changedLabel = null;
     let existIncludePoint = false;

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -202,7 +202,6 @@ export default class PCDLabelTool extends React.Component {
     }
     const posArray = this._currentPointMesh.geometry.getAttribute('position').array;
     let changedLabel = null;
-    let existIncludePoint = false;
     for (let i=0; i<bboxes.length; ++i) {
       const bbox = bboxes[i];
       let maxZ = -Infinity, minZ = Infinity;
@@ -217,13 +216,12 @@ export default class PCDLabelTool extends React.Component {
         const x = Math.abs( dx*Math.cos(yaw) + dy*Math.sin(yaw)),
               y = Math.abs(-dx*Math.sin(yaw) + dy*Math.cos(yaw));
         if (2*x < boxsx && 2*y < boxsy) {
-          existIncludePoint = true;
           const z = posArray[j+2];
           maxZ = Math.max(maxZ, z);
           minZ = Math.min(minZ, z);
         }
       }
-      if (!existIncludePoint) {
+      if (maxZ <= minZ) {
         continue;
       }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
Fix `SET HEIGHT` to select the target label.
When you are selecting a label, `SET HEIGHT` change only it.
Otherwise, all labels are changed.

## Related Tickets & Documents
This PR is related to #34.

